### PR TITLE
Replace Radix switch dependency with custom implementation

### DIFF
--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,19 +1,77 @@
 import * as React from "react";
-import * as SwitchPrimitives from "@radix-ui/react-switch";
+
 import { cn } from "@/lib/utils/cn";
 
-const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>>(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-slate-200",
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0" />
-  </SwitchPrimitives.Root>
-));
-Switch.displayName = SwitchPrimitives.Root.displayName;
+export interface SwitchProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  (
+    {
+      className,
+      checked = false,
+      onCheckedChange,
+      disabled = false,
+      type,
+      onClick,
+      onKeyDown,
+      ...props
+    },
+    ref
+  ) => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+
+      if (event.defaultPrevented || disabled) {
+        return;
+      }
+
+      onCheckedChange?.(!checked);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(event);
+
+      if (event.defaultPrevented || disabled) {
+        return;
+      }
+
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onCheckedChange?.(!checked);
+      }
+    };
+
+    return (
+      <button
+        type={type ?? "button"}
+        role="switch"
+        aria-checked={checked}
+        data-state={checked ? "checked" : "unchecked"}
+        data-disabled={disabled ? "" : undefined}
+        className={cn(
+          "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-slate-200",
+          className
+        )}
+        disabled={disabled}
+        ref={ref}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          data-state={checked ? "checked" : "unchecked"}
+          className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        />
+      </button>
+    );
+  }
+);
+
+Switch.displayName = "Switch";
 
 export { Switch };


### PR DESCRIPTION
## Summary
- remove the dependency on `@radix-ui/react-switch` by reimplementing the switch UI in house
- ensure the new switch supports keyboard, mouse, and accessibility attributes while keeping existing styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdf652ce248326a58b3c90ed76456d