### PR TITLE
Implement internal switch and drop Radix dependency

### DIFF
--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,28 +1,35 @@
-import * as React from "react";
+"use client";
+
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 
 import { cn } from "@/lib/utils/cn";
 
 export interface SwitchProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
 }
 
-const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   (
     {
       className,
       checked = false,
       onCheckedChange,
       disabled = false,
-      type,
+      type = "button",
       onClick,
       onKeyDown,
       ...props
     },
     ref
   ) => {
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
       onClick?.(event);
 
       if (event.defaultPrevented || disabled) {
@@ -32,7 +39,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
       onCheckedChange?.(!checked);
     };
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
       onKeyDown?.(event);
 
       if (event.defaultPrevented || disabled) {
@@ -47,9 +54,11 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
 
     return (
       <button
-        type={type ?? "button"}
+        ref={ref}
+        type={type}
         role="switch"
         aria-checked={checked}
+        aria-disabled={disabled || undefined}
         data-state={checked ? "checked" : "unchecked"}
         data-disabled={disabled ? "" : undefined}
         className={cn(
@@ -57,7 +66,6 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
           className
         )}
         disabled={disabled}
-        ref={ref}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "^2.0.0",
-        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-google-maps/api": "^2.19.3",
@@ -1247,35 +1246,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-switch": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
-      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
-    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-google-maps/api": "^2.19.3",


### PR DESCRIPTION
## Summary
- replace the UI switch component with a client-side implementation that handles toggle interactions without Radix
- remove the unused `@radix-ui/react-switch` dependency from the package manifests since the UI switch no longer requires it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdfaef1dc4832699d2228bf231328d